### PR TITLE
PR: Fix after removing replyingTo from state.

### DIFF
--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -92,7 +92,6 @@ const CommentBase = ({
 				{updating ? (
 					<Button
 						idAttribute="update"
-						replyingTo={replyingTo}
 						content="update"
 						updating={updating}
 						onClick={(e) => console.log(e.target.dataset)}

--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -74,8 +74,8 @@ const CommentBase = ({
 					updating={updating}
 					user={user}
 					content={content}
-					replyingTo={replyingTo}
 					currentUsername={currentUser.username}
+					replyingToUser={replyingToUser}
 					contentArea={contentArea}
 				/>
 

--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -106,7 +106,7 @@ const CommentBase = ({
 				<NewComment
 					replyingRef={replyingRef}
 					currentUser={currentUser}
-					replyingTo={user.username}
+					replyingToUser={user}
 				/>
 			) : null}
 		</>

--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -59,7 +59,7 @@ const CommentBase = ({
 				id={`${user.username}-${id}`}
 				className={`comment ${updating ? "updating" : ""}`}
 			>
-				<ScoreButtons id={id} replyingTo={replyingTo} score={score} />
+				<ScoreButtons id={id} score={score} />
 
 				{/* change class ? */}
 				<div className="comment-meta">

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -1,7 +1,7 @@
 const CommentContent = ({
 	user,
-	replyingTo,
 	currentUsername,
+	replyingToUser,
 	content,
 	contentArea,
 	updating,
@@ -21,9 +21,9 @@ const CommentContent = ({
 			}
 			ref={currentUsername === user.username && updating ? contentArea : null}
 		>
-			{replyingTo ? (
+			{!(replyingToUser == null) ? (
 				<>
-					<span className="replying-to">@{replyingTo}</span>{" "}
+					<span className="replying-to">@{replyingToUser}</span>{" "}
 				</>
 			) : null}
 			{content}


### PR DESCRIPTION
In `comments` objects, `replyingTo` is replaced by two properties:
- `replyingToUser`, the `id` of the **user** being replied to.
- `replyingToComment`, the `id` of the **comment** being replied to.