### PR TITLE
Fix <CommentContent /> #28 

### DIFF
--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -68,7 +68,7 @@ const CommentBase = ({
 
 				<CommentContent
 					updating={updating}
-					user={user}
+					authorID={user}
 					content={content}
 					replyingToUser={replyingToUser}
 					contentArea={contentArea}

--- a/src/features/comments/components/CommentBase.js
+++ b/src/features/comments/components/CommentBase.js
@@ -70,7 +70,6 @@ const CommentBase = ({
 					updating={updating}
 					user={user}
 					content={content}
-					currentUsername={currentUser.username}
 					replyingToUser={replyingToUser}
 					contentArea={contentArea}
 				/>

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -8,6 +8,9 @@ const CommentContent = ({
 	updating,
 }) => {
 	const currentUser = useSelector(selectCurrentUser);
+	// Determines whether the current user wrote the commnent being rendered
+	const byCurrentUser = currentUser.id === authorID;
+
 	return (
 		<div
 			// Add the .updating class to apply a border to the text area, visible when it loses focus

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -1,5 +1,5 @@
 const CommentContent = ({
-	user,
+	authorID,
 	replyingToUser,
 	content,
 	contentArea,

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -1,6 +1,5 @@
 const CommentContent = ({
 	user,
-	currentUsername,
 	replyingToUser,
 	content,
 	contentArea,

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -19,11 +19,11 @@ const CommentContent = ({
 
 	return (
 		<div
-			// Add the .updating class to apply a border to the text area, visible when it loses focus
+			// Add the .updating class to apply a border to the text area. The border makes it visible when it loses focus so that the user knows they can still enter text in that area.
 			className={`comment-content ${
 				byCurrentUser && updating ? "updating" : ""
 			}`}
-			// Check the user is the author of the comment and has clicked on edit button before making the div editable
+			// Check the user is the author of the comment **and** has clicked on edit button before making the div editable
 			contentEditable={byCurrentUser && updating ? true : false}
 			// remove React error
 			suppressContentEditableWarning={byCurrentUser ? true : null}
@@ -34,6 +34,7 @@ const CommentContent = ({
 				</>
 			) : null}
 			<span
+				// Apply focus if the user has started updating the comment
 				ref={byCurrentUser && updating ? contentArea : null}
 				className="content"
 			>

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -30,7 +30,7 @@ const CommentContent = ({
 		>
 			{!(replyingToUser == null) ? (
 				<>
-					<span className="replying-to">@{replyingToUser}</span>{" "}
+					<span className="replying-to">@{replyingToAuthor.username}</span>{" "}
 				</>
 			) : null}
 			<span

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -15,23 +15,24 @@ const CommentContent = ({
 		<div
 			// Add the .updating class to apply a border to the text area, visible when it loses focus
 			className={`comment-content ${
-				currentUsername === user.username && updating ? "updating" : ""
+				byCurrentUser && updating ? "updating" : ""
 			}`}
 			// Check the user is the author of the comment and has clicked on edit button before making the div editable
-			contentEditable={
-				currentUsername === user.username && updating ? true : false
-			}
-			suppressContentEditableWarning={
-				currentUsername === user.username ? true : null
-			}
-			ref={currentUsername === user.username && updating ? contentArea : null}
+			contentEditable={byCurrentUser && updating ? true : false}
+			// remove React error
+			suppressContentEditableWarning={byCurrentUser ? true : null}
 		>
 			{!(replyingToUser == null) ? (
 				<>
 					<span className="replying-to">@{replyingToUser}</span>{" "}
 				</>
 			) : null}
-			{content}
+			<span
+				ref={byCurrentUser && updating ? contentArea : null}
+				className="content"
+			>
+				{content}
+			</span>
 		</div>
 	);
 };

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -1,3 +1,5 @@
+import { useSelector } from "react-redux";
+import { selectCurrentUser } from "../../currentUser/currentUserSlice";
 const CommentContent = ({
 	authorID,
 	replyingToUser,
@@ -5,6 +7,7 @@ const CommentContent = ({
 	contentArea,
 	updating,
 }) => {
+	const currentUser = useSelector(selectCurrentUser);
 	return (
 		<div
 			// Add the .updating class to apply a border to the text area, visible when it loses focus

--- a/src/features/comments/components/CommentContent.js
+++ b/src/features/comments/components/CommentContent.js
@@ -1,5 +1,7 @@
 import { useSelector } from "react-redux";
 import { selectCurrentUser } from "../../currentUser/currentUserSlice";
+import { selectUserById } from "../../users/usersSlice";
+
 const CommentContent = ({
 	authorID,
 	replyingToUser,
@@ -8,6 +10,10 @@ const CommentContent = ({
 	updating,
 }) => {
 	const currentUser = useSelector(selectCurrentUser);
+	const replyingToAuthor = useSelector((state) =>
+		selectUserById(state, replyingToUser)
+	);
+
 	// Determines whether the current user wrote the commnent being rendered
 	const byCurrentUser = currentUser.id === authorID;
 


### PR DESCRIPTION
- Improve logic for conditional rendering.
- Improve legibility.
- Display `username` instead of `id` in the content when the comment is a reply.