### PR TITLE
Improve `comments/addReply`

### DIFF
--- a/src/features/comments/commentsSlice.js
+++ b/src/features/comments/commentsSlice.js
@@ -126,12 +126,9 @@ export const commentsSlice = createSlice({
 			// Add the comment to the state
 			state.push(newComment);
 
-			const repliedToComment = state.find(
-				(comment) =>
-					findRootComment(action.payload.replyingToComment) === comment.id
-			);
+			const rootComment = state.find((comment) => comment.id === rootCommentID);
 			// Finally, to display the newly added comment, push it to the list of replies of its root parent comment.
-			repliedToComment.replies.push(newComment.id);
+			rootComment.replies.push(newComment.id);
 		},
 		updateComment: () => {
 			// PUT comment


### PR DESCRIPTION
To be displayed properly, the new reply's `id` only needs to be in its root comment's `replies` array. Improve the correctness of data on replies:
- Store the actual comment being replied to in `replyingToComment` instead of the root comment's id previously.
- Improve code legibility.